### PR TITLE
Limit backup to opt directory

### DIFF
--- a/sellerbotbackup.sh
+++ b/sellerbotbackup.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # Bot token
-# گرفتن توکن ربات از کاربر و ذخیره آن در متغیر tk
 while [[ -z "$tk" ]]; do
     echo "Bot token: "
     read -r tk
@@ -12,7 +11,6 @@ while [[ -z "$tk" ]]; do
 done
 
 # Chat id
-# گرفتن Chat ID از کاربر و ذخیره آن در متغیر chatid
 while [[ -z "$chatid" ]]; do
     echo "Chat id: "
     read -r chatid
@@ -26,12 +24,10 @@ while [[ -z "$chatid" ]]; do
 done
 
 # Caption
-# گرفتن عنوان برای فایل پشتیبان و ذخیره آن در متغیر caption
-echo "Caption (for example, your domain, to identify the database file more easily): "
+echo "Caption (for example, your domain, to identify the backup file more easily): "
 read -r caption
 
 # Cronjob
-# تعیین زمانی برای اجرای این اسکریپت به صورت دوره‌ای
 while true; do
     echo "Cronjob (minutes and hours) (e.g : 30 6 or 0 12) : "
     read -r minute hour
@@ -52,21 +48,6 @@ while true; do
     fi
 done
 
-
-# x-ui or marzban or hiddify
-# گرفتن نوع نرم افزاری که می‌خواهیم پشتیبانی از آن بگیریم و ذخیره آن در متغیر xmh
-while [[ -z "$xmh" ]]; do
-    echo "x-ui or marzban or hiddify? [x/m/h] : "
-    read -r xmh
-    if [[ $xmh == $'\0' ]]; then
-        echo "Invalid input. Please choose x, m or h."
-        unset xmh
-    elif [[ ! $xmh =~ ^[xmh]$ ]]; then
-        echo "${xmh} is not a valid option. Please choose x, m or h."
-        unset xmh
-    fi
-done
-
 while [[ -z "$crontabs" ]]; do
     echo "Would you like the previous crontabs to be cleared? [y/n] : "
     read -r crontabs
@@ -80,153 +61,40 @@ while [[ -z "$crontabs" ]]; do
 done
 
 if [[ "$crontabs" == "y" ]]; then
-# remove cronjobs
-sudo crontab -l | grep -vE '/root/ac-backup.+\.sh' | crontab -
+    sudo crontab -l | grep -vE '/root/opt-backup.*\\.sh' | crontab -
 fi
 
-
-# m backup
-# ساخت فایل پشتیبانی برای نرم‌افزار Marzban و ذخیره آن در فایل ac-backup.zip
-if [[ "$xmh" == "m" ]]; then
-
-if dir=$(find /opt /root -type d -iname "marzban" -print -quit); then
-  echo "The folder exists at $dir"
-else
-  echo "The folder does not exist."
-  exit 1
+if [[ ! -d "/opt" ]]; then
+    echo "The /opt directory does not exist."
+    exit 1
 fi
-
-if [ -d "/var/lib/marzban/mysql" ]; then
-
-  sed -i -e 's/\s*=\s*/=/' -e 's/\s*:\s*/:/' -e 's/^\s*//' /opt/marzban/.env
-
-  docker exec marzban-mysql-1 bash -c "mkdir -p /var/lib/mysql/db-backup"
-  source /opt/marzban/.env
-
-    cat > "/var/lib/marzban/mysql/ac-backup.sh" <<EOL
-#!/bin/bash
-
-USER="root"
-PASSWORD="$MYSQL_ROOT_PASSWORD"
-
-
-databases=\$(mysql -h 127.0.0.1 --user=\$USER --password=\$PASSWORD -e "SHOW DATABASES;" | tr -d "| " | grep -v Database)
-
-for db in \$databases; do
-    if [[ "\$db" != "information_schema" ]] && [[ "\$db" != "mysql" ]] && [[ "\$db" != "performance_schema" ]] && [[ "\$db" != "sys" ]] ; then
-        echo "Dumping database: \$db"
-		mysqldump -h 127.0.0.1 --force --opt --user=\$USER --password=\$PASSWORD --databases \$db > /var/lib/mysql/db-backup/\$db.sql
-
-    fi
-done
-
-EOL
-chmod +x /var/lib/marzban/mysql/ac-backup.sh
-
-ZIP=$(cat <<EOF
-docker exec marzban-mysql-1 bash -c "/var/lib/mysql/ac-backup.sh"
-zip -r /root/ac-backup-m.zip /opt/marzban/* /var/lib/marzban/* /opt/marzban/.env /root/* /root/.env -x /var/lib/marzban/mysql/\*
-zip -r /root/ac-backup-m.zip /var/lib/marzban/mysql/db-backup/*
-rm -rf /var/lib/marzban/mysql/db-backup/*
-EOF
-)
-
-    else
-      ZIP="zip -r /root/ac-backup-m.zip ${dir}/* /var/lib/marzban/* /opt/marzban/.env"
-fi
-
-ACLover="marzban backup"
-
-# x-ui backup
-# ساخت فایل پشتیبانی برای نرم‌افزار X-UI و ذخیره آن در فایل ac-backup.zip
-elif [[ "$xmh" == "x" ]]; then
-
-if dbDir=$(find /etc /opt/freedom -type d -iname "x-ui*" -print -quit); then
-  echo "The folder exists at $dbDir"
-  if [[ $dbDir == *"/opt/freedom/x-ui"* ]]; then
-     dbDir="${dbDir}/db/"
-  fi
-else
-  echo "The folder does not exist."
-  exit 1
-fi
-
-if configDir=$(find /usr/local -type d -iname "x-ui*" -print -quit); then
-  echo "The folder exists at $configDir"
-else
-  echo "The folder does not exist."
-  exit 1
-fi
-
-ZIP="zip /root/ac-backup-x.zip ${dbDir}/x-ui.db ${configDir}/config.json"
-ACLover="x-ui backup"
-
-# hiddify backup
-# ساخت فایل پشتیبانی برای نرم‌افزار Hiddify و ذخیره آن در فایل ac-backup.zip
-elif [[ "$xmh" == "h" ]]; then
-
-if ! find /opt/hiddify-manager/hiddify-panel/ -type d -iname "backup" -print -quit; then
-  echo "The folder does not exist."
-  exit 1
-fi
-
-ZIP=$(cat <<EOF
-cd /opt/hiddify-manager/hiddify-panel/
-if [ $(find /opt/hiddify-manager/hiddify-panel/backup -type f | wc -l) -gt 100 ]; then
-  find /opt/hiddify-manager/hiddify-panel/backup -type f -delete
-fi
-python3 -m hiddifypanel backup
-cd /opt/hiddify-manager/hiddify-panel/backup
-latest_file=\$(ls -t *.json | head -n1)
-rm -f /root/ac-backup-h.zip
-zip /root/ac-backup-h.zip /opt/hiddify-manager/hiddify-panel/backup/\$latest_file
-
-EOF
-)
-ACLover="hiddify backup"
-else
-echo "Please choose m or x or h only !"
-exit 1
-fi
-
 
 trim() {
-    # remove leading and trailing whitespace/lines
     local var="$*"
-    # remove leading whitespace characters
     var="${var#"${var%%[![:space:]]*}"}"
-    # remove trailing whitespace characters
     var="${var%"${var##*[![:space:]]}"}"
     echo -n "$var"
 }
 
 IP=$(ip route get 1 | sed -n 's/^.*src \([0-9.]*\) .*$/\1/p')
-caption="${caption}\n\n${ACLover}\n<code>${IP}</code>\nCreated by @AC_Lover - https://github.com/AC-Lover/backup"
+caption="${caption}\n\n/opt backup\n<code>${IP}</code>\nCreated by @AC_Lover - https://github.com/AC-Lover/backup"
 comment=$(echo -e "$caption" | sed 's/<code>//g;s/<\/code>//g')
 comment=$(trim "$comment")
 
-# install zip
-# نصب پکیج zip
 sudo apt install zip -y
 
-# send backup to telegram
-# ارسال فایل پشتیبانی به تلگرام
-cat > "/root/ac-backup-${xmh}.sh" <<EOL
-rm -rf /root/ac-backup-${xmh}.zip
-$ZIP
-echo -e "$comment" | zip -z /root/ac-backup-${xmh}.zip
-curl -F chat_id="${chatid}" -F caption=\$'${caption}' -F parse_mode="HTML" -F document=@"/root/ac-backup-${xmh}.zip" https://api.telegram.org/bot${tk}/sendDocument
+cat > "/root/opt-backup.sh" <<EOL
+#!/bin/bash
+rm -f /root/opt-backup.zip
+zip -r /root/opt-backup.zip /opt
+echo -e "${comment}" | zip -z /root/opt-backup.zip
+curl -F chat_id="${chatid}" -F caption=\$'${caption}' -F parse_mode="HTML" -F document=@"/root/opt-backup.zip" https://api.telegram.org/bot${tk}/sendDocument
 EOL
 
+chmod +x /root/opt-backup.sh
 
-# Add cronjob
-# افزودن کرانجاب جدید برای اجرای دوره‌ای این اسکریپت
-{ crontab -l -u root; echo "${cron_time} /bin/bash /root/ac-backup-${xmh}.sh >/dev/null 2>&1"; } | crontab -u root -
+{ crontab -l -u root 2>/dev/null; echo "${cron_time} /bin/bash /root/opt-backup.sh >/dev/null 2>&1"; } | crontab -u root -
 
-# run the script
-# اجرای این اسکریپت
-bash "/root/ac-backup-${xmh}.sh"
+bash "/root/opt-backup.sh"
 
-# Done
-# پایان اجرای اسکریپت
 echo -e "\nDone\n"


### PR DESCRIPTION
## Summary
- simplify the backup script to only package the contents of /opt
- generate a reusable /root/opt-backup.sh helper and cron entry for the archive
- update the caption/comment formatting to reflect the new scope

## Testing
- shellcheck sellerbotbackup.sh *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68cf88538b908326a03fafffa443d094